### PR TITLE
histogram intersection distance

### DIFF
--- a/src/Distance.jl
+++ b/src/Distance.jl
@@ -30,6 +30,7 @@ export
     KLDivergence,
     JSDivergence,
     SpanNormDist,
+    HistIntersection,
 
     WeightedEuclidean,
     WeightedSqEuclidean,
@@ -54,6 +55,7 @@ export
     kl_divergence,
     js_divergence,
     spannorm_dist,
+    histintersect_dist,
 
     weuclidean,
     wsqeuclidean,

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -27,6 +27,8 @@ type JSDivergence <: SemiMetric end
 
 type SpanNormDist <: SemiMetric end
 
+type HistIntersection <: Metric end
+
 
 ###########################################################
 #
@@ -329,4 +331,19 @@ end
 
 spannorm_dist(a::AbstractVector, b::AbstractVector) = evaluate(SpanNormDist(), a, b)
 
+
+# Histogram intersection distance
+
+function evaluate(dist::HistIntersection, a::AbstractVector, b::AbstractVector)
+    d = 0.0
+    sb = 0.0
+    for i = 1 : length(a)
+        @inbounds ai = a[i]
+        @inbounds bi = b[i]
+        d += (ai > bi ? bi : ai)
+        sb += bi
+    end
+    1.0 - d/sb
+end
+histintersect_dist(a::AbstractVector, b::AbstractVector) = evaluate(HistIntersection(), a, b)
 

--- a/test/test_dists.jl
+++ b/test/test_dists.jl
@@ -84,6 +84,9 @@ jsv = kl_divergence(p, pm) / 2 + kl_divergence(q, pm) / 2
 @test spannorm_dist(x, x) == 0.
 @test spannorm_dist(x, y) == maximum(x - y) - minimum(x - y)
 
+@test_approx_eq_eps histintersect_dist(a,a) 0.0 1.0e-12
+@test_approx_eq_eps histintersect_dist(a,b) 1.0-(sum(b)-1.)/sum(b) 1.0e-12
+
 w = rand(size(x))
 
 @test wsqeuclidean(x, x, w) == 0.


### PR DESCRIPTION
Histogram intersection distance: HID(a,b) = 1 - Σₜmin(aₜ, bₜ)/Σₜbₜ. It is used for partial histogram matching.

It is a variation of [Earth mover's distance](http://en.wikipedia.org/wiki/Earth_mover%27s_distance) with histogram intersection kernel, K(a,b) = Σₜmin(aₜ, bₜ). If using only kernel for calculating distance then positive definiteness does not hold, d(x,x)≠0. So, trick with 1-(normalized kernel value) is used.  In its turn,  normalization brakes symmetry axiom, d(x,y)≠d(y,x), because of the dependency on one of the parameters. So, it is not a proper metric, even though triangle inequality property is satisfied. 
